### PR TITLE
.gitignore に ./idea を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/ruby,rails,sublimetext,vim,jetbrains,linux,osx,windows
+
+# User add
+.idea/


### PR DESCRIPTION
Rubymineを使用している影響で、`commit`の際に`./idea`のファイルが残ってしまっていました。そのため、`.gitignore`に`./idea`を追加しました。