### PR TITLE
数字が変わるタイミングと回数を修正した

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -6,8 +6,8 @@
 <% end %>
 
 <script>
-  var shuffleNumber = 40;
-  var waitTime = 125;
+  var shuffleNumber = 60;
+  var waitTime = 100;
   var cnt = 0;
   var ranBef = 0;
   function randomNumber (maxNumber, minNumber) {


### PR DESCRIPTION
Close #84

## 変更前・変更後の変化について
### `var shuffleNumber = 40;  var waitTime = 125;`（変更前）の場合
![shufflenumber_before](https://user-images.githubusercontent.com/21003658/30676110-61e28ad0-9ebf-11e7-8f9e-07bd9044eb4b.gif)

### `var shuffleNumber = 60;  var waitTime = 100;`（変更後）の場合
![shufflenumber_after](https://user-images.githubusercontent.com/21003658/30676121-67d34e20-9ebf-11e7-8c3f-7cf85526502e.gif)

## 修正について
「shuffleNumber」がランダムに数字を表示する回数、「waitTime」が数字切り替えのタイミングで合ったことから、切り替えるタイミングを早くし、シャッフル回数を増やすことでもっさりとした動作の改善をしました。
複数回確認しましたが、こちらの方法でもっさり感が軽減されたのではないかと思います。